### PR TITLE
Opt gemini-cli out of branch_protections

### DIFF
--- a/branch_protection.yaml
+++ b/branch_protection.yaml
@@ -1,3 +1,5 @@
 optConfig:
   optOutStrategy: true
+  optOutRepos:
+  - gemini-cli
 action: issue


### PR DESCRIPTION
gemini-cli uses branch ruleset which is not yet supported by allstar